### PR TITLE
Update/add run command listeners

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-xterm-lib",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A library for terminals.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/NrfTerminalCommander.ts
+++ b/src/NrfTerminalCommander.ts
@@ -269,10 +269,10 @@ export default class NrfTerminalCommander implements ITerminalAddon {
      * started, i.e. because a command was just run.
      */
     private breakCurrentCommand() {
+        this.#lineCount += 1;
         this.#terminal.write(this.#prompt.value);
         this.#historyAddon.resetCursor();
         this._output = '';
-        this.#lineCount += 1;
     }
 
     private onData(data: string): void {

--- a/src/addons/CopyPasteAddon.ts
+++ b/src/addons/CopyPasteAddon.ts
@@ -21,7 +21,15 @@ export default class CopyPasteAddon extends NrfTerminalAddon {
             }
 
             if (isPaste(domEvent)) {
-                document.execCommand('paste');
+                navigator.clipboard.readText().then(clipText => {
+                    const lines = clipText.split('\n');
+                    const remainder = lines.pop()!;
+                    lines.forEach(line => {
+                        this.terminal.paste(line);
+                        this.commander.runCommand(line.trim());
+                    });
+                    this.commander.replaceInputWith(remainder)
+                });
             }
         });
     }


### PR DESCRIPTION
This PR contains a few changes:

- f43b169 - Previously we had no way to handle newlines in pasted content, this commit should fix that problem.
- 79e911c - Currently anyone who is using this library has to add their own output handling to know when a command has been executed. This commit will add the possibility to add `runCommandListeners` which allows any users to pass in a callback that will be run with argument `command` whenever `command` is executed.
- ed40bcf - Fixes a small bug where the prompt number was not properly incremented after the first command.
