### PR TITLE
Rename user input

### DIFF
--- a/lib/NrfTerminalCommander.d.ts
+++ b/lib/NrfTerminalCommander.d.ts
@@ -6,18 +6,19 @@ export interface KeyEvent {
     key: string;
     domEvent: KeyboardEvent;
 }
-export declare type OutputListener = (output: string) => void;
+export declare type UserInputChangeListener = (userInput: string) => void;
+export declare type RunCommandListener = (command: string) => void;
 export interface NrfTerminalConfig {
     /**
      * The string to be displayed at the start of each new line.
      */
     prompt: string;
     /**
-     * A function that, given the current output, returns the list
+     * A function that, given the current user input, returns the list
      * of autocompletion entries that should be displayed.
      *
      * @example
-     * function completer(output: string) {
+     * function completer(userInput: string) {
      *   const completions: Completion[] = [
      *      {
      *        value: "toggle_autcomplete",
@@ -25,7 +26,7 @@ export interface NrfTerminalConfig {
      *      }
      *   ];
      *
-     *   return completions.filter(c => c.value.beginsWith(output));
+     *   return completions.filter(c => c.value.beginsWith(userInput));
      * }
      */
     completerFunction: CompleterFunction;
@@ -67,10 +68,10 @@ export default class NrfTerminalCommander implements ITerminalAddon {
     activate(terminal: Terminal): void;
     dispose(): boolean;
     /**
-     * The value of the current line.
+     * The current user input.
      */
-    get output(): string;
-    private set _output(value);
+    get userInput(): string;
+    private set _userInput(value);
     /**
      * The number of lines spanned by the current command.
      */
@@ -89,27 +90,24 @@ export default class NrfTerminalCommander implements ITerminalAddon {
      */
     private registerCustomCommands;
     /**
-     * Registers a function that will be called whenever the output changes,
-     * with the new output value.
-     * @param listener The function to call when the output changes.
+     * Registers a function that will be called whenever the user input changes,
+     * with the new user input.
+     * @param listener The function to call when the user input changes.
+     * @returns a function to unregister the listener
      */
-    registerOutputListener(listener: (output: string) => void): void;
+    onUserInputChange(listener: UserInputChangeListener): () => void;
     /**
      * Registers a function that will be called whenever the a command is run,
      * with the command value.
      * @param listener The function to call when a command is run.
+     * @returns a function to unregister the listener
      */
-    registerRunCommandListener(listener: (command: string) => void): void;
+    onRunCommand(listener: RunCommandListener): () => void;
     /**
-     * Removes all functions that are called whenever a command is run
+     * Replaces the user input currently being entered into the buffer.
+     * @param newUserInput The user input written to the screen. Defaults to an empty string.
      */
-    clearRunCommandListeners(): void;
-    /**
-     * Removes the command currently being entered into the buffer
-     * and replaces it with `newCommand`.
-     * @param newCommand The command to write to the screen.
-     */
-    replaceInputWith(newCommand: string): void;
+    replaceUserInput(newUserInput?: string): void;
     /**
      * Returns `true` if the cursor is placed at the beginning of
      * the line (i.e. right after the prompt), otherwise `false`.
@@ -125,7 +123,7 @@ export default class NrfTerminalCommander implements ITerminalAddon {
      * Removes all the typed characters on the current line, and
      * moves the cursor to the beginning.
      */
-    clearInput(): void;
+    clearUserInput(): void;
     private backspace;
     private moveCaretLeft;
     private moveCaretRight;

--- a/lib/NrfTerminalCommander.js
+++ b/lib/NrfTerminalCommander.js
@@ -34,7 +34,7 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-var _terminal, _prompt, _config, _historyAddon, _lineSpan, _lineCount, _outputValue, _registeredCommands, _outputListeners, _runCommandListeners;
+var _terminal, _prompt, _config, _historyAddon, _lineSpan, _lineCount, _userInput_1, _registeredCommands, _userInputChangeListeners, _runCommandListeners;
 Object.defineProperty(exports, "__esModule", { value: true });
 const ansi = __importStar(require("ansi-escapes"));
 const Prompt_1 = __importDefault(require("./Prompt"));
@@ -63,9 +63,9 @@ class NrfTerminalCommander {
         _historyAddon.set(this, void 0);
         _lineSpan.set(this, 0);
         _lineCount.set(this, 1);
-        _outputValue.set(this, '');
+        _userInput_1.set(this, '');
         _registeredCommands.set(this, {});
-        _outputListeners.set(this, []);
+        _userInputChangeListeners.set(this, []);
         _runCommandListeners.set(this, []);
         __classPrivateFieldSet(this, _config, config);
         __classPrivateFieldSet(this, _prompt, new Prompt_1.default(this, config.prompt));
@@ -103,14 +103,14 @@ class NrfTerminalCommander {
         return false;
     }
     /**
-     * The value of the current line.
+     * The current user input.
      */
-    get output() {
-        return __classPrivateFieldGet(this, _outputValue);
+    get userInput() {
+        return __classPrivateFieldGet(this, _userInput_1);
     }
-    set _output(newOutput) {
-        __classPrivateFieldSet(this, _outputValue, newOutput);
-        __classPrivateFieldGet(this, _outputListeners).forEach(l => l(this.output));
+    set _userInput(newUserInput) {
+        __classPrivateFieldSet(this, _userInput_1, newUserInput);
+        __classPrivateFieldGet(this, _userInputChangeListeners).forEach(l => l(this.userInput));
     }
     /**
      * The number of lines spanned by the current command.
@@ -142,36 +142,33 @@ class NrfTerminalCommander {
         }
     }
     /**
-     * Registers a function that will be called whenever the output changes,
-     * with the new output value.
-     * @param listener The function to call when the output changes.
+     * Registers a function that will be called whenever the user input changes,
+     * with the new user input.
+     * @param listener The function to call when the user input changes.
+     * @returns a function to unregister the listener
      */
-    registerOutputListener(listener) {
-        __classPrivateFieldGet(this, _outputListeners).push(listener);
+    onUserInputChange(listener) {
+        __classPrivateFieldGet(this, _userInputChangeListeners).push(listener);
+        return () => (__classPrivateFieldSet(this, _userInputChangeListeners, __classPrivateFieldGet(this, _userInputChangeListeners).filter(l => l !== listener)));
     }
     /**
      * Registers a function that will be called whenever the a command is run,
      * with the command value.
      * @param listener The function to call when a command is run.
+     * @returns a function to unregister the listener
      */
-    registerRunCommandListener(listener) {
+    onRunCommand(listener) {
         __classPrivateFieldGet(this, _runCommandListeners).push(listener);
+        return () => (__classPrivateFieldSet(this, _runCommandListeners, __classPrivateFieldGet(this, _runCommandListeners).filter(l => l !== listener)));
     }
     /**
-     * Removes all functions that are called whenever a command is run
+     * Replaces the user input currently being entered into the buffer.
+     * @param newUserInput The user input written to the screen. Defaults to an empty string.
      */
-    clearRunCommandListeners() {
-        __classPrivateFieldSet(this, _runCommandListeners, []);
-    }
-    /**
-     * Removes the command currently being entered into the buffer
-     * and replaces it with `newCommand`.
-     * @param newCommand The command to write to the screen.
-     */
-    replaceInputWith(newCommand) {
-        this.clearInput();
-        __classPrivateFieldGet(this, _terminal).write(newCommand);
-        this._output = newCommand;
+    replaceUserInput(newUserInput = '') {
+        this.clearUserInput();
+        __classPrivateFieldGet(this, _terminal).write(newUserInput);
+        this._userInput = newUserInput;
     }
     /**
      * Returns `true` if the cursor is placed at the beginning of
@@ -187,7 +184,7 @@ class NrfTerminalCommander {
      * otherwise `false`.
      */
     atEndOfLine() {
-        const maxRightCursor = __classPrivateFieldGet(this, _prompt).length - 2 + this.output.length;
+        const maxRightCursor = __classPrivateFieldGet(this, _prompt).length - 2 + this.userInput.length;
         const buffer = __classPrivateFieldGet(this, _terminal).buffer.active;
         return buffer.cursorX >= maxRightCursor;
     }
@@ -195,8 +192,8 @@ class NrfTerminalCommander {
      * Removes all the typed characters on the current line, and
      * moves the cursor to the beginning.
      */
-    clearInput() {
-        const charsToDelete = this.output.length - 1;
+    clearUserInput() {
+        const charsToDelete = this.userInput.length - 1;
         for (let i = 0; i <= charsToDelete; i += 1) {
             this.backspace();
         }
@@ -204,7 +201,7 @@ class NrfTerminalCommander {
     backspace() {
         if (!this.atBeginningOfLine()) {
             __classPrivateFieldGet(this, _terminal).write('\b \b');
-            this._output = this.output.slice(0, this.output.length - 1);
+            this._userInput = this.userInput.slice(0, this.userInput.length - 1);
         }
     }
     moveCaretLeft() {
@@ -218,7 +215,7 @@ class NrfTerminalCommander {
         }
     }
     runCommand(cmd) {
-        const command = cmd || this.output.trim();
+        const command = cmd || this.userInput.trim();
         if (command.length) {
             const callback = __classPrivateFieldGet(this, _registeredCommands)[command];
             if (callback) {
@@ -237,7 +234,7 @@ class NrfTerminalCommander {
         __classPrivateFieldSet(this, _lineCount, __classPrivateFieldGet(this, _lineCount) + 1);
         __classPrivateFieldGet(this, _terminal).write(__classPrivateFieldGet(this, _prompt).value);
         __classPrivateFieldGet(this, _historyAddon).resetCursor();
-        this._output = '';
+        this._userInput = '';
     }
     onData(data) {
         switch (utils_1.charCode(data)) {
@@ -251,7 +248,7 @@ class NrfTerminalCommander {
                     return this.runCommand();
                 }
         }
-        this._output = this.output + data;
+        this._userInput = this.userInput + data;
         this.updateLineSpan();
         this.autocompleteAddon.enable();
         __classPrivateFieldGet(this, _terminal).write(data);
@@ -278,8 +275,8 @@ class NrfTerminalCommander {
     }
     updateLineSpan() {
         const delta = __classPrivateFieldGet(this, _terminal).cols - __classPrivateFieldGet(this, _prompt).length;
-        __classPrivateFieldSet(this, _lineSpan, Math.floor(this.output.length / delta));
+        __classPrivateFieldSet(this, _lineSpan, Math.floor(this.userInput.length / delta));
     }
 }
 exports.default = NrfTerminalCommander;
-_terminal = new WeakMap(), _prompt = new WeakMap(), _config = new WeakMap(), _historyAddon = new WeakMap(), _lineSpan = new WeakMap(), _lineCount = new WeakMap(), _outputValue = new WeakMap(), _registeredCommands = new WeakMap(), _outputListeners = new WeakMap(), _runCommandListeners = new WeakMap();
+_terminal = new WeakMap(), _prompt = new WeakMap(), _config = new WeakMap(), _historyAddon = new WeakMap(), _lineSpan = new WeakMap(), _lineCount = new WeakMap(), _userInput_1 = new WeakMap(), _registeredCommands = new WeakMap(), _userInputChangeListeners = new WeakMap(), _runCommandListeners = new WeakMap();

--- a/lib/addons/AutocompleteAddon.d.ts
+++ b/lib/addons/AutocompleteAddon.d.ts
@@ -4,7 +4,7 @@ export interface Completion {
     value: string;
     description: string;
 }
-export declare type CompleterFunction = (output: string) => Completion[];
+export declare type CompleterFunction = (userInput: string) => Completion[];
 export default class AutocompleteAddon extends NrfTerminalAddon {
     #private;
     name: string;

--- a/lib/addons/AutocompleteAddon.js
+++ b/lib/addons/AutocompleteAddon.js
@@ -15,7 +15,7 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-var _isVisible, _suggestions, _root, _container, _completerFunction, _highlightedIndex, _prevOutput, _hasCancelled;
+var _isVisible, _suggestions, _root, _container, _completerFunction, _highlightedIndex, _prevUserInput, _hasCancelled;
 Object.defineProperty(exports, "__esModule", { value: true });
 const NrfTerminalAddon_1 = __importDefault(require("../NrfTerminalAddon"));
 const HIGHLIGHTED_CLASS = 'autocomplete__suggestion--highlighted';
@@ -29,7 +29,7 @@ class AutocompleteAddon extends NrfTerminalAddon_1.default {
         _container.set(this, void 0);
         _completerFunction.set(this, void 0);
         _highlightedIndex.set(this, 0);
-        _prevOutput.set(this, '');
+        _prevUserInput.set(this, '');
         _hasCancelled.set(this, false);
         __classPrivateFieldSet(this, _completerFunction, completer);
     }
@@ -43,16 +43,16 @@ class AutocompleteAddon extends NrfTerminalAddon_1.default {
         __classPrivateFieldSet(this, _hasCancelled, false);
     }
     get completions() {
-        return __classPrivateFieldGet(this, _completerFunction).call(this, this.commander.output);
+        return __classPrivateFieldGet(this, _completerFunction).call(this, this.commander.userInput);
     }
     onActivate() {
-        this.commander.registerOutputListener(output => {
+        this.commander.onUserInputChange(userInput => {
             if (!__classPrivateFieldGet(this, _container)) {
                 this.initialiseContainer();
             }
             if (!__classPrivateFieldGet(this, _hasCancelled)) {
-                this.patchSuggestionBox(output);
-                this.repositionX(output);
+                this.patchSuggestionBox(userInput);
+                this.repositionX(userInput);
                 this.repositionY(this.commander.lineCount);
             }
         });
@@ -112,21 +112,21 @@ class AutocompleteAddon extends NrfTerminalAddon_1.default {
     selectSuggestion(id) {
         const { value } = this.completions[id];
         // Write out the portion of the value that hasn't already been typed.
-        const completed = value.slice(this.commander.output.length);
+        const completed = value.slice(this.commander.userInput.length);
         this.terminal.write(completed);
         this.clearSuggestions();
     }
-    patchSuggestionBox(output) {
-        if (!output.length) {
+    patchSuggestionBox(userInput) {
+        if (!userInput.length) {
             this.clearSuggestions();
             return;
         }
         for (let i = 0; i < this.completions.length; i += 1) {
             const completion = this.completions[i];
-            const isMatch = completion.value.startsWith(output);
+            const isMatch = completion.value.startsWith(userInput);
             const alreadyShowing = __classPrivateFieldGet(this, _suggestions).includes(i);
             if (isMatch && alreadyShowing) {
-                if (output.length < __classPrivateFieldGet(this, _prevOutput).length) {
+                if (userInput.length < __classPrivateFieldGet(this, _prevUserInput).length) {
                     this.shrinkMatch(i);
                 }
                 else {
@@ -134,23 +134,23 @@ class AutocompleteAddon extends NrfTerminalAddon_1.default {
                 }
             }
             else if (isMatch && !alreadyShowing) {
-                this.addSuggestion(i, output);
+                this.addSuggestion(i, userInput);
             }
             else if (!isMatch && alreadyShowing) {
                 this.removeSuggestion(i);
             }
         }
-        __classPrivateFieldSet(this, _prevOutput, output);
+        __classPrivateFieldSet(this, _prevUserInput, userInput);
     }
-    addSuggestion(id, output) {
+    addSuggestion(id, userInput) {
         var _a;
         const { value: suggestionValue } = this.completions[id];
         const matchedSpan = document.createElement('span');
-        matchedSpan.textContent = output;
+        matchedSpan.textContent = userInput;
         matchedSpan.className = 'font-weight-bolder';
         matchedSpan.dataset.type = 'matched';
         const unmatchedSpan = document.createElement('span');
-        const regex = new RegExp(`^${output}`, 'gm');
+        const regex = new RegExp(`^${userInput}`, 'gm');
         const unmatchedFragment = suggestionValue.split(regex)[1];
         unmatchedSpan.textContent = unmatchedFragment;
         unmatchedSpan.dataset.type = 'unmatched';
@@ -208,8 +208,8 @@ class AutocompleteAddon extends NrfTerminalAddon_1.default {
         }
         return suggestionLi;
     }
-    repositionX(output) {
-        const left = output.length * 3.5 + 80 + (5 * output.length - 1) - 3.5;
+    repositionX(userInput) {
+        const left = userInput.length * 3.5 + 80 + (5 * userInput.length - 1) - 3.5;
         __classPrivateFieldGet(this, _root).style.left = `${left}px`;
     }
     repositionY(lineNo) {
@@ -218,4 +218,4 @@ class AutocompleteAddon extends NrfTerminalAddon_1.default {
     }
 }
 exports.default = AutocompleteAddon;
-_isVisible = new WeakMap(), _suggestions = new WeakMap(), _root = new WeakMap(), _container = new WeakMap(), _completerFunction = new WeakMap(), _highlightedIndex = new WeakMap(), _prevOutput = new WeakMap(), _hasCancelled = new WeakMap();
+_isVisible = new WeakMap(), _suggestions = new WeakMap(), _root = new WeakMap(), _container = new WeakMap(), _completerFunction = new WeakMap(), _highlightedIndex = new WeakMap(), _prevUserInput = new WeakMap(), _hasCancelled = new WeakMap();

--- a/lib/addons/CopyPasteAddon.js
+++ b/lib/addons/CopyPasteAddon.js
@@ -33,7 +33,7 @@ class CopyPasteAddon extends NrfTerminalAddon_1.default {
                         this.terminal.paste(line);
                         this.commander.runCommand(line.trim());
                     });
-                    this.commander.replaceInputWith(remainder);
+                    this.commander.replaceUserInput(remainder);
                 });
             }
         });

--- a/lib/addons/HistoryAddon.js
+++ b/lib/addons/HistoryAddon.js
@@ -29,8 +29,8 @@ class HistoryAddon extends NrfTerminalAddon_1.default {
     onActivate() {
         this.terminal.onData(data => {
             if (utils_1.charCode(data) === utils_1.CharCodes.LF &&
-                this.commander.output.trim().length) {
-                this.addToHistory(this.commander.output);
+                this.commander.userInput.trim().length) {
+                this.addToHistory(this.commander.userInput);
                 this.resetCursor();
             }
         });
@@ -57,13 +57,13 @@ class HistoryAddon extends NrfTerminalAddon_1.default {
             return;
         __classPrivateFieldSet(this, _currentIndex, __classPrivateFieldGet(this, _currentIndex) - 1);
         const command = __classPrivateFieldGet(this, _currentIndex) === -1 ? '' : this.currentCommand;
-        this.commander.replaceInputWith(command);
+        this.commander.replaceUserInput(command);
     }
     moveBackwards() {
         if (__classPrivateFieldGet(this, _currentIndex) >= this.history.length - 1)
             return;
         __classPrivateFieldSet(this, _currentIndex, __classPrivateFieldGet(this, _currentIndex) + 1);
-        this.commander.replaceInputWith(this.currentCommand);
+        this.commander.replaceUserInput(this.currentCommand);
     }
     /**
      * A list of commands saved to the history list.

--- a/lib/addons/TimestampAddon.js
+++ b/lib/addons/TimestampAddon.js
@@ -72,7 +72,7 @@ class TimestampAddon extends NrfTerminalAddon_1.default {
         const now = new Date();
         const formatted = dateFns.format(now, this.format);
         const endCols = this.terminal.cols -
-            this.commander.output.length -
+            this.commander.userInput.length -
             formatted.length -
             this.commander.prompt.length;
         this.terminal.write(ansi.cursorForward(endCols));

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "format": "prettier -w src/*/**",
+    "format": "prettier -w src/**",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/src/NrfTerminalCommander.ts
+++ b/src/NrfTerminalCommander.ts
@@ -178,8 +178,10 @@ export default class NrfTerminalCommander implements ITerminalAddon {
      * Registers all custom commands from the provided config
      */
     private registerCustomCommands(): void {
-        for (const [command, callback] of Object.entries(this.#config.commands)) {
-            this.registerCommand(command, callback)
+        for (const [command, callback] of Object.entries(
+            this.#config.commands
+        )) {
+            this.registerCommand(command, callback);
         }
     }
 
@@ -189,11 +191,15 @@ export default class NrfTerminalCommander implements ITerminalAddon {
      * @param listener The function to call when the output changes.
      * @returns a function to unregister the listener
      */
-    public registerOutputListener(listener: (output: string) => void): () => void {
+    public registerOutputListener(
+        listener: (output: string) => void
+    ): () => void {
         this.#outputListeners.push(listener);
 
         return () =>
-            this.#outputListeners = this.#outputListeners.filter(l => l !== listener);
+            (this.#outputListeners = this.#outputListeners.filter(
+                l => l !== listener
+            ));
     }
 
     /**
@@ -202,11 +208,15 @@ export default class NrfTerminalCommander implements ITerminalAddon {
      * @param listener The function to call when a command is run.
      * @returns a function to unregister the listener
      */
-    public registerRunCommandListener(listener: (command: string) => void): () => void {
+    public registerRunCommandListener(
+        listener: (command: string) => void
+    ): () => void {
         this.#runCommandListeners.push(listener);
 
         return () =>
-            this.#runCommandListeners = this.#runCommandListeners.filter(l => l !== listener);
+            (this.#runCommandListeners = this.#runCommandListeners.filter(
+                l => l !== listener
+            ));
     }
 
     /**

--- a/src/NrfTerminalCommander.ts
+++ b/src/NrfTerminalCommander.ts
@@ -211,9 +211,9 @@ export default class NrfTerminalCommander implements ITerminalAddon {
     /**
      * Removes the command currently being entered into the buffer
      * and replaces it with `newCommand`.
-     * @param newCommand The command to write to the screen.
+     * @param newCommand The command to write to the screen. Defaults to an empty string.
      */
-    public replaceInputWith(newCommand: string): void {
+    public replaceInputWith(newCommand: string = ''): void {
         this.clearInput();
         this.#terminal.write(newCommand);
         this._output = newCommand;

--- a/src/NrfTerminalCommander.ts
+++ b/src/NrfTerminalCommander.ts
@@ -192,9 +192,7 @@ export default class NrfTerminalCommander implements ITerminalAddon {
      * @param listener The function to call when the user input changes.
      * @returns a function to unregister the listener
      */
-    public registerUserInputChangeListener(
-        listener: UserInputChangeListener
-    ): () => void {
+    public onUserInputChange(listener: UserInputChangeListener): () => void {
         this.#userInputChangeListeners.push(listener);
 
         return () =>
@@ -209,9 +207,7 @@ export default class NrfTerminalCommander implements ITerminalAddon {
      * @param listener The function to call when a command is run.
      * @returns a function to unregister the listener
      */
-    public registerRunCommandListener(
-        listener: RunCommandListener
-    ): () => void {
+    public onRunCommand(listener: RunCommandListener): () => void {
         this.#runCommandListeners.push(listener);
 
         return () =>

--- a/src/NrfTerminalCommander.ts
+++ b/src/NrfTerminalCommander.ts
@@ -17,7 +17,7 @@ export interface KeyEvent {
     domEvent: KeyboardEvent;
 }
 
-export type OutputListener = (output: string) => void;
+export type UserInputChangeListener = (userInput: string) => void;
 export type RunCommandListener = (command: string) => void;
 
 export interface NrfTerminalConfig {
@@ -26,11 +26,11 @@ export interface NrfTerminalConfig {
      */
     prompt: string;
     /**
-     * A function that, given the current output, returns the list
+     * A function that, given the current user input, returns the list
      * of autocompletion entries that should be displayed.
      *
      * @example
-     * function completer(output: string) {
+     * function completer(userInput: string) {
      *   const completions: Completion[] = [
      *      {
      *        value: "toggle_autcomplete",
@@ -38,7 +38,7 @@ export interface NrfTerminalConfig {
      *      }
      *   ];
      *
-     *   return completions.filter(c => c.value.beginsWith(output));
+     *   return completions.filter(c => c.value.beginsWith(userInput));
      * }
      */
     completerFunction: CompleterFunction;
@@ -81,10 +81,10 @@ export default class NrfTerminalCommander implements ITerminalAddon {
 
     #lineSpan = 0;
     #lineCount = 1;
-    #outputValue = '';
+    #userInput = '';
 
     #registeredCommands: { [command: string]: () => void } = {};
-    #outputListeners: OutputListener[] = [];
+    #userInputChangeListeners: UserInputChangeListener[] = [];
     #runCommandListeners: RunCommandListener[] = [];
 
     constructor(config: NrfTerminalConfig) {
@@ -139,15 +139,15 @@ export default class NrfTerminalCommander implements ITerminalAddon {
     }
 
     /**
-     * The value of the current line.
+     * The current user input.
      */
-    public get output() {
-        return this.#outputValue;
+    public get userInput() {
+        return this.#userInput;
     }
 
-    private set _output(newOutput: string) {
-        this.#outputValue = newOutput;
-        this.#outputListeners.forEach(l => l(this.output));
+    private set _userInput(newUserInput: string) {
+        this.#userInput = newUserInput;
+        this.#userInputChangeListeners.forEach(l => l(this.userInput));
     }
 
     /**
@@ -187,16 +187,18 @@ export default class NrfTerminalCommander implements ITerminalAddon {
     }
 
     /**
-     * Registers a function that will be called whenever the output changes,
-     * with the new output value.
-     * @param listener The function to call when the output changes.
+     * Registers a function that will be called whenever the user input changes,
+     * with the new user input.
+     * @param listener The function to call when the user input changes.
      * @returns a function to unregister the listener
      */
-    public registerOutputListener(listener: OutputListener): () => void {
-        this.#outputListeners.push(listener);
+    public registerUserInputChangeListener(
+        listener: UserInputChangeListener
+    ): () => void {
+        this.#userInputChangeListeners.push(listener);
 
         return () =>
-            (this.#outputListeners = this.#outputListeners.filter(
+            (this.#userInputChangeListeners = this.#userInputChangeListeners.filter(
                 l => l !== listener
             ));
     }
@@ -219,14 +221,13 @@ export default class NrfTerminalCommander implements ITerminalAddon {
     }
 
     /**
-     * Removes the command currently being entered into the buffer
-     * and replaces it with `newCommand`.
-     * @param newCommand The command to write to the screen. Defaults to an empty string.
+     * Replaces the user input currently being entered into the buffer.
+     * @param newUserInput The user input written to the screen. Defaults to an empty string.
      */
-    public replaceInputWith(newCommand: string = ''): void {
-        this.clearInput();
-        this.#terminal.write(newCommand);
-        this._output = newCommand;
+    public replaceUserInput(newUserInput: string = ''): void {
+        this.clearUserInput();
+        this.#terminal.write(newUserInput);
+        this._userInput = newUserInput;
     }
 
     /**
@@ -244,7 +245,7 @@ export default class NrfTerminalCommander implements ITerminalAddon {
      * otherwise `false`.
      */
     public atEndOfLine(): boolean {
-        const maxRightCursor = this.#prompt.length - 2 + this.output.length;
+        const maxRightCursor = this.#prompt.length - 2 + this.userInput.length;
         const buffer = this.#terminal.buffer.active;
         return buffer.cursorX >= maxRightCursor;
     }
@@ -253,8 +254,8 @@ export default class NrfTerminalCommander implements ITerminalAddon {
      * Removes all the typed characters on the current line, and
      * moves the cursor to the beginning.
      */
-    public clearInput(): void {
-        const charsToDelete = this.output.length - 1;
+    public clearUserInput(): void {
+        const charsToDelete = this.userInput.length - 1;
         for (let i = 0; i <= charsToDelete; i += 1) {
             this.backspace();
         }
@@ -263,7 +264,10 @@ export default class NrfTerminalCommander implements ITerminalAddon {
     private backspace(): void {
         if (!this.atBeginningOfLine()) {
             this.#terminal.write('\b \b');
-            this._output = this.output.slice(0, this.output.length - 1);
+            this._userInput = this.userInput.slice(
+                0,
+                this.userInput.length - 1
+            );
         }
     }
 
@@ -280,7 +284,7 @@ export default class NrfTerminalCommander implements ITerminalAddon {
     }
 
     public runCommand(cmd?: string): void {
-        const command = cmd || this.output.trim();
+        const command = cmd || this.userInput.trim();
         if (command.length) {
             const callback = this.#registeredCommands[command];
             if (callback) {
@@ -300,7 +304,7 @@ export default class NrfTerminalCommander implements ITerminalAddon {
         this.#lineCount += 1;
         this.#terminal.write(this.#prompt.value);
         this.#historyAddon.resetCursor();
-        this._output = '';
+        this._userInput = '';
     }
 
     private onData(data: string): void {
@@ -318,7 +322,7 @@ export default class NrfTerminalCommander implements ITerminalAddon {
                 }
         }
 
-        this._output = this.output + data;
+        this._userInput = this.userInput + data;
         this.updateLineSpan();
         this.autocompleteAddon.enable();
         this.#terminal.write(data);
@@ -347,6 +351,6 @@ export default class NrfTerminalCommander implements ITerminalAddon {
 
     private updateLineSpan() {
         const delta = this.#terminal.cols - this.#prompt.length;
-        this.#lineSpan = Math.floor(this.output.length / delta);
+        this.#lineSpan = Math.floor(this.userInput.length / delta);
     }
 }

--- a/src/NrfTerminalCommander.ts
+++ b/src/NrfTerminalCommander.ts
@@ -187,25 +187,26 @@ export default class NrfTerminalCommander implements ITerminalAddon {
      * Registers a function that will be called whenever the output changes,
      * with the new output value.
      * @param listener The function to call when the output changes.
+     * @returns a function to unregister the listener
      */
-    public registerOutputListener(listener: (output: string) => void): void {
+    public registerOutputListener(listener: (output: string) => void): () => void {
         this.#outputListeners.push(listener);
+
+        return () =>
+            this.#outputListeners = this.#outputListeners.filter(l => l !== listener);
     }
 
     /**
      * Registers a function that will be called whenever the a command is run,
      * with the command value.
      * @param listener The function to call when a command is run.
+     * @returns a function to unregister the listener
      */
-    public registerRunCommandListener(listener: (command: string) => void): void {
+    public registerRunCommandListener(listener: (command: string) => void): () => void {
         this.#runCommandListeners.push(listener);
-    }
 
-    /**
-     * Removes all functions that are called whenever a command is run
-     */
-    public clearRunCommandListeners(): void {
-        this.#runCommandListeners = [];
+        return () =>
+            this.#runCommandListeners = this.#runCommandListeners.filter(l => l !== listener);
     }
 
     /**

--- a/src/NrfTerminalCommander.ts
+++ b/src/NrfTerminalCommander.ts
@@ -18,6 +18,7 @@ export interface KeyEvent {
 }
 
 export type OutputListener = (output: string) => void;
+export type RunCommandListener = (command: string) => void;
 
 export interface NrfTerminalConfig {
     /**
@@ -84,7 +85,7 @@ export default class NrfTerminalCommander implements ITerminalAddon {
 
     #registeredCommands: { [command: string]: () => void } = {};
     #outputListeners: OutputListener[] = [];
-    #runCommandListeners: ((command: string) => void)[] = [];
+    #runCommandListeners: RunCommandListener[] = [];
 
     constructor(config: NrfTerminalConfig) {
         this.#config = config;
@@ -191,9 +192,7 @@ export default class NrfTerminalCommander implements ITerminalAddon {
      * @param listener The function to call when the output changes.
      * @returns a function to unregister the listener
      */
-    public registerOutputListener(
-        listener: (output: string) => void
-    ): () => void {
+    public registerOutputListener(listener: OutputListener): () => void {
         this.#outputListeners.push(listener);
 
         return () =>
@@ -209,7 +208,7 @@ export default class NrfTerminalCommander implements ITerminalAddon {
      * @returns a function to unregister the listener
      */
     public registerRunCommandListener(
-        listener: (command: string) => void
+        listener: RunCommandListener
     ): () => void {
         this.#runCommandListeners.push(listener);
 

--- a/src/addons/AutocompleteAddon.ts
+++ b/src/addons/AutocompleteAddon.ts
@@ -44,7 +44,7 @@ export default class AutocompleteAddon extends NrfTerminalAddon {
     }
 
     protected onActivate() {
-        this.commander.registerUserInputChangeListener(userInput => {
+        this.commander.onUserInputChange(userInput => {
             if (!this.#container) {
                 this.initialiseContainer();
             }

--- a/src/addons/CopyPasteAddon.ts
+++ b/src/addons/CopyPasteAddon.ts
@@ -23,12 +23,12 @@ export default class CopyPasteAddon extends NrfTerminalAddon {
             if (isPaste(domEvent)) {
                 navigator.clipboard.readText().then(clipText => {
                     const lines = clipText.split('\n');
-                    const remainder = lines.pop()!;
+                    const remainder = lines.pop();
                     lines.forEach(line => {
                         this.terminal.paste(line);
                         this.commander.runCommand(line.trim());
                     });
-                    this.commander.replaceInputWith(remainder)
+                    this.commander.replaceInputWith(remainder);
                 });
             }
         });

--- a/src/addons/CopyPasteAddon.ts
+++ b/src/addons/CopyPasteAddon.ts
@@ -28,7 +28,7 @@ export default class CopyPasteAddon extends NrfTerminalAddon {
                         this.terminal.paste(line);
                         this.commander.runCommand(line.trim());
                     });
-                    this.commander.replaceInputWith(remainder);
+                    this.commander.replaceUserInput(remainder);
                 });
             }
         });

--- a/src/addons/HistoryAddon.ts
+++ b/src/addons/HistoryAddon.ts
@@ -11,9 +11,9 @@ export default class HistoryAddon extends NrfTerminalAddon {
         this.terminal.onData(data => {
             if (
                 charCode(data) === CharCodes.LF &&
-                this.commander.output.trim().length
+                this.commander.userInput.trim().length
             ) {
-                this.addToHistory(this.commander.output);
+                this.addToHistory(this.commander.userInput);
                 this.resetCursor();
             }
         });
@@ -42,13 +42,13 @@ export default class HistoryAddon extends NrfTerminalAddon {
         if (this.#currentIndex < 0) return;
         this.#currentIndex -= 1;
         const command = this.#currentIndex === -1 ? '' : this.currentCommand;
-        this.commander.replaceInputWith(command);
+        this.commander.replaceUserInput(command);
     }
 
     private moveBackwards(): void {
         if (this.#currentIndex >= this.history.length - 1) return;
         this.#currentIndex += 1;
-        this.commander.replaceInputWith(this.currentCommand);
+        this.commander.replaceUserInput(this.currentCommand);
     }
 
     /**

--- a/src/addons/TimestampAddon.ts
+++ b/src/addons/TimestampAddon.ts
@@ -48,7 +48,7 @@ export default class TimestampAddon extends NrfTerminalAddon {
 
         const endCols =
             this.terminal.cols -
-            this.commander.output.length -
+            this.commander.userInput.length -
             formatted.length -
             this.commander.prompt.length;
 


### PR DESCRIPTION
Several smaller changes:
- Remove a non-null assertion in https://github.com/NordicPlayground/pc-xterm-lib/blob/f43b169c384661920147f7458419a22e45204ffe/src/addons/CopyPasteAddon.ts#L26
- Unify the listeners for changed user input and running commands
- Format all sources in `src/` (previously only source in folders below `src/` were formatted when running `npm run format`)
- Unify naming to "user input": What users put into the terminal was previously sometimes called "input" and sometimes "output" (because following the typewrite model it was also echoed back by the terminal). This unifies that naming to "user
input".
