### PR TITLE
Fix/several issues

### DIFF
--- a/lib/NrfTerminalCommander.js
+++ b/lib/NrfTerminalCommander.js
@@ -213,6 +213,7 @@ class NrfTerminalCommander {
         }
     }
     runCommand(cmd) {
+        this.breakCurrentCommand();
         const command = cmd || this.userInput.trim();
         if (command.length) {
             const callback = __classPrivateFieldGet(this, _registeredCommands)[command];
@@ -221,7 +222,6 @@ class NrfTerminalCommander {
             }
             __classPrivateFieldGet(this, _runCommandListeners).forEach(l => l(command));
         }
-        this.breakCurrentCommand();
     }
     /**
      * Prints a new prompt and removes the currently entered

--- a/lib/NrfTerminalCommander.js
+++ b/lib/NrfTerminalCommander.js
@@ -193,10 +193,8 @@ class NrfTerminalCommander {
      * moves the cursor to the beginning.
      */
     clearUserInput() {
-        const charsToDelete = this.userInput.length - 1;
-        for (let i = 0; i <= charsToDelete; i += 1) {
-            this.backspace();
-        }
+        __classPrivateFieldGet(this, _terminal).write(ansi.cursorTo(__classPrivateFieldGet(this, _prompt).length - 2));
+        __classPrivateFieldGet(this, _terminal).write(ansi.eraseEndLine);
     }
     backspace() {
         if (!this.atBeginningOfLine()) {

--- a/lib/addons/AutocompleteAddon.js
+++ b/lib/addons/AutocompleteAddon.js
@@ -15,7 +15,7 @@ var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
-var _isVisible, _suggestions, _root, _container, _completerFunction, _highlightedIndex, _prevUserInput, _hasCancelled;
+var _suggestions, _root, _container, _completerFunction, _highlightedIndex, _prevUserInput, _hasCancelled;
 Object.defineProperty(exports, "__esModule", { value: true });
 const NrfTerminalAddon_1 = __importDefault(require("../NrfTerminalAddon"));
 const HIGHLIGHTED_CLASS = 'autocomplete__suggestion--highlighted';
@@ -23,7 +23,6 @@ class AutocompleteAddon extends NrfTerminalAddon_1.default {
     constructor(commander, completer) {
         super(commander);
         this.name = 'AutocompleteAddon';
-        _isVisible.set(this, false);
         _suggestions.set(this, []);
         _root.set(this, void 0);
         _container.set(this, void 0);
@@ -34,7 +33,7 @@ class AutocompleteAddon extends NrfTerminalAddon_1.default {
         __classPrivateFieldSet(this, _completerFunction, completer);
     }
     get isVisible() {
-        return __classPrivateFieldGet(this, _isVisible);
+        return __classPrivateFieldGet(this, _suggestions).length > 0;
     }
     disable() {
         __classPrivateFieldSet(this, _hasCancelled, true);
@@ -59,16 +58,17 @@ class AutocompleteAddon extends NrfTerminalAddon_1.default {
         this.terminal.onKey(({ domEvent }) => {
             switch (domEvent.code) {
                 case 'ArrowUp':
-                    return this.navigateUp();
+                    if (this.isVisible)
+                        return this.navigateUp();
                 case 'ArrowDown':
-                    return this.navigateDown();
+                    if (this.isVisible)
+                        return this.navigateDown();
                 case 'Escape':
                     __classPrivateFieldSet(this, _hasCancelled, true);
                     return this.clearSuggestions();
                 case 'Enter':
-                    if (this.isVisible) {
+                    if (this.isVisible)
                         return this.selectSuggestion(__classPrivateFieldGet(this, _highlightedIndex));
-                    }
                 // Swallow backspace keys so they don't revert the cancel.
                 // This way the dialog will only appear again on a real keypress.
                 case 'Backspace':
@@ -162,7 +162,6 @@ class AutocompleteAddon extends NrfTerminalAddon_1.default {
         }
         (_a = __classPrivateFieldGet(this, _container)) === null || _a === void 0 ? void 0 : _a.appendChild(suggestionLi);
         __classPrivateFieldGet(this, _suggestions).push(id);
-        __classPrivateFieldSet(this, _isVisible, true);
     }
     removeSuggestion(id) {
         var _a;
@@ -195,7 +194,6 @@ class AutocompleteAddon extends NrfTerminalAddon_1.default {
             return;
         __classPrivateFieldGet(this, _container).innerHTML = '';
         __classPrivateFieldSet(this, _suggestions, []);
-        __classPrivateFieldSet(this, _isVisible, false);
         __classPrivateFieldSet(this, _highlightedIndex, 0);
     }
     getSuggestionElement(id) {
@@ -216,4 +214,4 @@ class AutocompleteAddon extends NrfTerminalAddon_1.default {
     }
 }
 exports.default = AutocompleteAddon;
-_isVisible = new WeakMap(), _suggestions = new WeakMap(), _root = new WeakMap(), _container = new WeakMap(), _completerFunction = new WeakMap(), _highlightedIndex = new WeakMap(), _prevUserInput = new WeakMap(), _hasCancelled = new WeakMap();
+_suggestions = new WeakMap(), _root = new WeakMap(), _container = new WeakMap(), _completerFunction = new WeakMap(), _highlightedIndex = new WeakMap(), _prevUserInput = new WeakMap(), _hasCancelled = new WeakMap();

--- a/src/NrfTerminalCommander.ts
+++ b/src/NrfTerminalCommander.ts
@@ -278,6 +278,7 @@ export default class NrfTerminalCommander implements ITerminalAddon {
     }
 
     public runCommand(cmd?: string): void {
+        this.breakCurrentCommand();
         const command = cmd || this.userInput.trim();
         if (command.length) {
             const callback = this.#registeredCommands[command];
@@ -286,7 +287,6 @@ export default class NrfTerminalCommander implements ITerminalAddon {
             }
             this.#runCommandListeners.forEach(l => l(command));
         }
-        this.breakCurrentCommand();
     }
 
     /**

--- a/src/NrfTerminalCommander.ts
+++ b/src/NrfTerminalCommander.ts
@@ -251,10 +251,8 @@ export default class NrfTerminalCommander implements ITerminalAddon {
      * moves the cursor to the beginning.
      */
     public clearUserInput(): void {
-        const charsToDelete = this.userInput.length - 1;
-        for (let i = 0; i <= charsToDelete; i += 1) {
-            this.backspace();
-        }
+        this.#terminal.write(ansi.cursorTo(this.#prompt.length - 2));
+        this.#terminal.write(ansi.eraseEndLine);
     }
 
     private backspace(): void {

--- a/src/addons/AutocompleteAddon.ts
+++ b/src/addons/AutocompleteAddon.ts
@@ -13,7 +13,6 @@ const HIGHLIGHTED_CLASS = 'autocomplete__suggestion--highlighted';
 export default class AutocompleteAddon extends NrfTerminalAddon {
     name = 'AutocompleteAddon';
 
-    #isVisible = false;
     #suggestions: number[] = [];
     #root?: HTMLDivElement;
     #container?: HTMLUListElement;
@@ -28,7 +27,7 @@ export default class AutocompleteAddon extends NrfTerminalAddon {
     }
 
     public get isVisible() {
-        return this.#isVisible;
+        return this.#suggestions.length > 0;
     }
 
     public disable() {
@@ -59,16 +58,14 @@ export default class AutocompleteAddon extends NrfTerminalAddon {
         this.terminal.onKey(({ domEvent }) => {
             switch (domEvent.code) {
                 case 'ArrowUp':
-                    return this.navigateUp();
+                    if (this.isVisible) return this.navigateUp();
                 case 'ArrowDown':
-                    return this.navigateDown();
+                    if (this.isVisible) return this.navigateDown();
                 case 'Escape':
                     this.#hasCancelled = true;
                     return this.clearSuggestions();
                 case 'Enter':
-                    if (this.isVisible) {
-                        return this.selectSuggestion(this.#highlightedIndex);
-                    }
+                    if (this.isVisible) return this.selectSuggestion(this.#highlightedIndex);
                 // Swallow backspace keys so they don't revert the cancel.
                 // This way the dialog will only appear again on a real keypress.
                 case 'Backspace':
@@ -174,7 +171,6 @@ export default class AutocompleteAddon extends NrfTerminalAddon {
 
         this.#container?.appendChild(suggestionLi);
         this.#suggestions.push(id);
-        this.#isVisible = true;
     }
 
     private removeSuggestion(id: number): void {
@@ -210,7 +206,6 @@ export default class AutocompleteAddon extends NrfTerminalAddon {
         if (!this.#container) return;
         this.#container.innerHTML = '';
         this.#suggestions = [];
-        this.#isVisible = false;
         this.#highlightedIndex = 0;
     }
 


### PR DESCRIPTION
- 1c96b27 - Fix issue where we would get an error in the console when pressing Arrow up/down if the autocomplete window was not open
- 180c336 - Fix issue where navigating history in the middle of a command would mess up break the terminal layout.
![history_bug](https://user-images.githubusercontent.com/72191781/110755985-e4eea280-8249-11eb-8b9f-3fc974e89cd9.gif)

- 0433cad - Change ordering of events so that any errors or other responses are shown after the command which was run. In the screenshot below the first `AT` command is queued, and the second `AT` command causes an error, but it looks like it was the first command that caused it.
![image](https://user-images.githubusercontent.com/72191781/110756158-241cf380-824a-11eb-9c05-70ccbcae7ab2.png)
