### PR TITLE
Move 'displayName' back to the bottom

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,24 +5,25 @@ pool:
   vmImage: ubuntu-20.04
 
 steps:
-- displayName: Install Node.js
-  task: NodeTool@0
+- task: NodeTool@0
   inputs:
     versionSpec: 14
-- displayName: Install dependencies
-  script: |
+  displayName: Install Node.js
+- script: |
     set -o errexit -o pipefail
     npm ci
-- displayName: Run linter
-  script: |
+  displayName: Install dependencies
+- script: |
     set -o errexit -o pipefail
     npm run format
-- displayName: Build
-  script: |
+  displayName: Run linter
+- script: |
     set -o errexit -o pipefail
     npm run build
     npm run dist
-- displayName: Check copyright statements
-  script: |
+  displayName: Build
+- script: |
     set -o errexit -o pipefail
     npm run copyright -- check
+  displayName: Check copyright statements
+


### PR DESCRIPTION
This reverts commit 1358055acb82bdea7c57bea9af4e74bb6c51d665.

It seems like the pipeline is failing:

  https://dev.azure.com/NordicSemiconductor/Wayland/_build/results?buildId=14733&view=results

And it is potentially related to this. I would have thought that each
list item is interpretted as an object with keys and so the order of the
keys doesn't matter but it seems like they need to start with 'task',
'script' or 'bash'. Not sure.